### PR TITLE
update license information - no CC BY-NC 4.0 any longer

### DIFF
--- a/io.admin-shell.idta.batterypass.circularity/1.0.0/Circularity.ttl
+++ b/io.admin-shell.idta.batterypass.circularity/1.0.0/Circularity.ttl
@@ -12,11 +12,10 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.0.0/BatteryNameplate.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.0.0/BatteryNameplate.ttl
@@ -8,15 +8,14 @@
 # https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #
-# namespace: urn:samm:io.BatteryPass
+# namespace: urn:samm:io.BatteryPass:GeneralProductInformation
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.material_composition/1.0.0/MaterialComposition.ttl
+++ b/io.admin-shell.idta.batterypass.material_composition/1.0.0/MaterialComposition.ttl
@@ -9,15 +9,14 @@
 # https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #
-# namespace: urn:samm:io.BatteryPass.MaterialComposition:1.2.0
+# namespace: urn:samm:io.BatteryPass.MaterialComposition
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductCondition.ttl
+++ b/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductCondition.ttl
@@ -12,11 +12,10 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductConditionIndustrialLmt.ttl
+++ b/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductConditionIndustrialLmt.ttl
@@ -8,15 +8,14 @@
 # https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #
-# namespace: urn:samm:io.BatteryPass
+# namespace: urn:samm:io.BatteryPass.Performance
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductCondition_shared.ttl
+++ b/io.admin-shell.idta.batterypass.product_condition/1.0.0/ProductCondition_shared.ttl
@@ -12,11 +12,10 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.technical_data/1.0.0/TechnicalData.ttl
+++ b/io.admin-shell.idta.batterypass.technical_data/1.0.0/TechnicalData.ttl
@@ -12,24 +12,13 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
-#######################################################################
-
-######################################################################
-# Copyright (c) 2025 Bosch Connected Industry
-# Copyright (c) 2025 Industrial Digital Twin Association
-# This work  is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
-# which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+#@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
 @prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.technical_data/1.0.0/technicalProperties_scalar_shared.ttl
+++ b/io.admin-shell.idta.batterypass.technical_data/1.0.0/technicalProperties_scalar_shared.ttl
@@ -12,22 +12,12 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
-#######################################################################
-
-######################################################################
-# Copyright (c) 2025 Bosch Connected Industry
-# Copyright (c) 2025 Industrial Digital Twin Association
-# This work  is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
-# which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
+
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .

--- a/io.admin-shell.idta.batterypass.technical_data/1.0.0/technicalProperties_shared.ttl
+++ b/io.admin-shell.idta.batterypass.technical_data/1.0.0/technicalProperties_shared.ttl
@@ -12,22 +12,12 @@
 # Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
 #
 # The referenced work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
-#
-# SPDX-License-Identifier: CC-BY-NC-4.0
-#######################################################################
-
-######################################################################
-# Copyright (c) 2025 Bosch Connected Industry
-# Copyright (c) 2025 Industrial Digital Twin Association
-# This work  is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
-# which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
+
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .


### PR DESCRIPTION
licensing was corrected in io.battery: information updated + fix of some incorrect license information