### PR TITLE
digital nameplate battery 1.1.0 economic operator information

### DIFF
--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/AddressInformation_shared.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/AddressInformation_shared.ttl
@@ -23,14 +23,25 @@
 @prefix shared: <urn:samm:io.admin-shell.idta.shared:3.1.0#> .
 
 
-:addressInformation a samm:Property ;
+:manufacturerAddressInformation a samm:Property ;
    samm:preferredName "Addresse des Herstellers"@de ;
-   samm:preferredName "adress of the manufacturer"@en ;
-   samm:description "The manufacturer information postal address, indicating a single contact point. Web address, if available; and web address, if available.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3"@en ;
+   samm:preferredName "address of the manufacturer"@en ;
+   samm:description "The manufacturer information postal address, indicating a single contact point. Web address, if available; and web address, if available.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.4"@en ;
    samm:see <https://adminshell.io/zvei/nameplate/1/0/ContactInformations/AddressInformation> ;
    samm:see <https://admin-shell.io/smt-dropin/smt-dropin-use/1/0> ;
    samm:see <urn:irdi:0112/2///61360_7#AAS002#001> ;
    samm:see <urn:irdi:0173-1#02-AAQ837#008/0173-1#01-ADR448#008> ;
    samm:see <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#addressInformation> ;
    samm:characteristic nameplate:AddressInformationCharacteristic .
+   
+:economicOperatorAddressInformation a samm:Property ;
+   samm:preferredName "address of the economic opearator"@en ;
+   samm:description "The economic operator information postal address, indicating a single contact point. Web address, if available; and web address, if available.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3"@en ;
+   samm:see <https://adminshell.io/zvei/nameplate/1/0/ContactInformations/AddressInformation> ;
+   samm:see <https://admin-shell.io/smt-dropin/smt-dropin-use/1/0> ;
+   samm:see <urn:irdi:0112/2///61360_7#AAS002#001> ;
+   samm:see <urn:irdi:0173-1#02-AAQ837#008/0173-1#01-ADR448#008> ;
+   samm:see <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#addressInformation> ;
+   samm:characteristic nameplate:AddressInformationCharacteristic .   
+
 

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/AddressInformation_shared.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/AddressInformation_shared.ttl
@@ -1,0 +1,36 @@
+######################################################################
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Industrial Digital Twin Association
+# This work  is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.1.0#> .
+@prefix nameplate: <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#> .
+@prefix contactInformation: <urn:samm:io.admin-shell.idta.contact_information:1.0.0#> .
+@prefix shared: <urn:samm:io.admin-shell.idta.shared:3.1.0#> .
+
+
+:addressInformation a samm:Property ;
+   samm:preferredName "Addresse des Herstellers"@de ;
+   samm:preferredName "adress of the manufacturer"@en ;
+   samm:description "The manufacturer information postal address, indicating a single contact point. Web address, if available; and web address, if available.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3"@en ;
+   samm:see <https://adminshell.io/zvei/nameplate/1/0/ContactInformations/AddressInformation> ;
+   samm:see <https://admin-shell.io/smt-dropin/smt-dropin-use/1/0> ;
+   samm:see <urn:irdi:0112/2///61360_7#AAS002#001> ;
+   samm:see <urn:irdi:0173-1#02-AAQ837#008/0173-1#01-ADR448#008> ;
+   samm:see <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#addressInformation> ;
+   samm:characteristic nameplate:AddressInformationCharacteristic .
+

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
@@ -25,7 +25,7 @@
 @prefix shared: <urn:samm:io.admin-shell.idta.shared:3.1.0#> .
 @prefix nameplate: <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#> .
 @prefix contactInformation: <urn:samm:io.admin-shell.idta.contact_information:1.0.0#> .
-@prefix tech: <urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#> 
+@prefix tech: <urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#> .
 @prefix : <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.1.0#> .
 
 

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
@@ -1,0 +1,164 @@
+######################################################################
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Industrial Digital Twin Association
+# This work  is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# elements of namespace: urn:samm:io.BatteryPass:GeneralProductInformation:1.2.0 
+# within https://github.com/batterypass/BatteryPassDataModel
+# with licence CC-BY-4.0
+# and Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
+# are used but enhanced, adapted or changed to be compliant with DIN DKE SPEC 99100 
+#
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix shared: <urn:samm:io.admin-shell.idta.shared:3.1.0#> .
+@prefix nameplate: <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#> .
+@prefix contactInformation: <urn:samm:io.admin-shell.idta.contact_information:1.0.0#> .
+@prefix tech: <urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#> 
+@prefix : <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.1.0#> .
+
+
+:BatteryNameplate a samm:Aspect ;
+   samm:preferredName "nameplate for battery passport"@en ;
+   samm:preferredName "Typenschild für den Batteriepass"@de ;
+   samm:description "Contains the nameplate information attached to the product within the Battery Product Passport."@en ;
+   samm:description "Enthält die Information zum Typenschild des Produkts im Digitalen Batteriepass."@de ;
+   samm:properties ( 
+   [ samm:property :uriOfTheProduct; samm:payloadName "URIOfTheProduct" ] 
+   [ samm:property :manufacturerName; samm:payloadName "ManufacturerName" ] 
+   [ samm:property :addressInformation; samm:payloadName "AddressInformation" ] 
+   [ samm:property :serialNumber; samm:payloadName "SerialNumber" ] 
+   [ samm:property :dateOfManufacture; samm:payloadName "DateOfManufacture" ] 
+   [ samm:property :dateOfPuttingIntoService; samm:optional true; samm:payloadName "DateOfPuttingIntoService" ] 
+   [ samm:property :uniqueFacilityIdentifier; samm:payloadName "UniqueFacilityIdentifier" ]
+   [ samm:property :batteryStatus; samm:payloadName "LifeCycleStage" ]
+   [ samm:property :operatorIdentifier; samm:optional true; samm:payloadName "OperatorIdentifier" ] 
+   [ samm:property tech:manufacturerIdentifier; samm:payloadName "ManufacturerIdentifier" ] 
+   [ samm:property :markings; samm:payloadName "Markings" ] 
+   [ samm:property :euDeclarationOfConformity; samm:payloadName "EUDeclarationOfConformity" ] 
+   [ samm:property :resultsOfTestReportsProvingCompliance; samm:payloadName "ResultsOfTestReportsProvingCompliance" ] 
+   );
+   samm:operations ( ) ;
+   samm:events ( ) ;
+   samm:see <https://admin-shell.io/idta/nameplate/3/0/Nameplate> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0> .
+
+:uriOfTheProduct a samm:Property ;
+   samm:preferredName "URI des Produkts"@de ;
+   samm:preferredName "URI of the product"@en ;
+   samm:description "Unique global identification of the product instance using an universal resource identifier (URI).\n The battery passport identifier is the unique identifier of a battery passport.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.1"@en ;
+   samm:see <urn:irdi:0112/2///61987%23ABN590%23002> ;
+   samm:see <urn:irdi:0173-1%2302-ABH173%23003> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#uriOfTheProduct> ;
+   samm:characteristic nameplate:Uri ;
+   samm:exampleValue "https://dc-qr.com/?m=R123456789"^^xsd:anyURI .
+
+:manufacturerName a samm:Property ;
+   samm:preferredName "manufacturer name"@en ;
+   samm:preferredName "Herstellername"@de ;
+   samm:description "Legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation.\n\n Information identifying the manufacturer with a name.Information identifying the manufacturer with a name.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.1"@en ;
+   samm:description "Name des Herstellers."@de ;
+   samm:see <urn:irdi:0112/2///61987%23ABA565%23009> ;
+   samm:see <urn:irdi:0173-1%2302-AAO677%23004> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#manufacturerName> ;
+   samm:exampleValue "Muster AG"@de ;
+   samm:characteristic shared:MultiLanguageTexts .
+
+:serialNumber a samm:Property ;
+   samm:preferredName "Seriennummer"@de ;
+   samm:preferredName "serial number"@en ;
+   samm:description "Die Seriennummer des Produkts."@de ;
+   samm:description "Unique combination of numbers and letters used to identify the device once it has been manufactured.\n\n The battery identifier should be serialised, i.e., identifying each battery via a serial number.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.2"@en ;
+   samm:see <urn:irdi:0112/2///61987%23ABA951%23009> ;
+   samm:see <urn:irdi:0173-1%2302-AAM556%23004> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#serialNumber> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A12345-X75EN" .
+
+:dateOfManufacture a samm:Property ;
+   samm:preferredName "date of manufacture"@en ;
+   samm:preferredName "Herstelldatum"@de ;
+   samm:description "Date when an item was manufactured.\n\n The manufacturing date should not only relate to the battery model, but to the battery item. The date code should comply with DINISO8601-1:2020-12 and ISO8601-2:2019.\n\n DIN DKE Spec 99100 chapter reference: 6.1.3.2"@en ;
+   samm:description "Datum, zu dem das Produkt hergestellt wurde."@de ;
+   samm:see <urn:irdi:0112/2///61987%23ABB757%23007> ;
+   samm:see <urn:irdi:0173-1%2302-AAR972%23004> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#dateOfManufacture> ;
+   samm:characteristic nameplate:Date ;
+   samm:exampleValue "2022-01-01"^^xsd:date .
+
+:dateOfPuttingIntoService a samm:Property ;
+   samm:preferredName "date of putting into service"@en ;
+   samm:description "Where appropriate, the battery passport must include information on the date of putting the battery into service. BR Annex VI Part A (1); Art. 3(33); Art. 38(7); ESPR Art. 2(32)\n\nDIN DKE Spec chapter reference: 6.1.3.3"@en ;
+   samm:characteristic :PuttingIntoServiceDate ;
+   samm:exampleValue "2022-06-01"^^xsd:date .
+
+:uniqueFacilityIdentifier a samm:Property ;
+   samm:preferredName "unique Identifier of a facility"@en ;
+   samm:description "Unique string of characters for the identification of locations or buildings involved in a product’s value chain or used by actors involved in a product’s value chain.\n\n The manufacturing place should be uniquely identifiable.\n\n DIN DKE Spec 99100 chapter reference: 6.1.3.1"@en ;
+   samm:see <https://adminshell.io/idta/nameplate/3/0/UniqueFacilityIdentifier> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#uniqueFacilityIdentifier> ;
+   samm:see <urn:irdi:0173-1#02-AAV646#003> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "987654321" .
+
+   
+:batteryStatus a samm:Property ;
+   samm:preferredName "BatteryStatus"@en ;
+   samm:description """A battery passport must include information on the life cycle status of the battery.
+   
+   The status of the battery must be defined as 'original' (0173-1#07-ACC020#001), 'repurposed'(0173-1#07-ACC021#001), 're-used'(0173-1#07-ACC022#001), 'remanufactured' (0173-1#07-ACC023#001) or 'waste' (0173-1#07-ACC024#001).
+   
+   A new battery passport must be issued when a battery was subject to remanufacturing, repurpose or one of the treatment operations preparing for re-use and preparing for repurpose and is placed on the market again.
+   
+   DIN DKE Spec 99100 chapter reference: 6.1.3.7"""@en ;
+   samm:characteristic :BatteryStatusEnumeration ;
+   samm:exampleValue :Original .
+ 
+:operatorIdentifier a samm:Property ;
+   samm:preferredName "identifier of the operator"@en ;
+   samm:description "The unique operator identifier should comply with ISO/IEC 15459 1:2014, ISO/IEC 15459 2:2015, ISO/IEC 15459 3:2014, ISO/IEC 15459 4:2014, ISO/IEC 15459 5:2014, ISO/IEC 15459 6:2014, or their equivalent until referenced harmonised standards are listed in the OJEU.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3"@en ;
+   samm:characteristic samm-c:Text .
+ 
+:markings a samm:Property ;
+   samm:preferredName "markings"@en ;
+   samm:preferredName "Kennzeichnungen"@de ;
+   samm:description """Should be used to provide all relevant marking information of the battery passport based on DIN DKE SPEC 99100 such as:
+
+* Separate collection symbol (6.2.2)
+* Symbols for cadmium and lead (6.2.3)
+* Carbon footprint label (6.2.4)
+* Extinguishing agent (6.2.5)
+* Meaning of labels and symbols (6.2.6)
+* EU declaration of conformity (6.2.7)
+* Results of test reports proving compliance (6.2.8)
+
+Note: CE marking is declared as mandatory according to EU Blue Guide 
+   """@en ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#markings> ;
+   samm:characteristic shared:Markings .
+ 
+:euDeclarationOfConformity a samm:Property ;
+   samm:preferredName "EU declaration of conformity"@en ;
+   samm:description "A battery passport must include the EU declaration of conformity.\n\n  DIN DKE Spec 99100 chapter reference: 6.2.7 \n\n Document identifiers (e.g., depending of different languages) of a document (e.g., PDF) that can be found in the Handover Documentation model."@en ;
+   samm:see <urn:irdi:0173-1#02-ABA889#003> ;
+   samm:characteristic shared:DocumentIdentifierSet .
+
+:resultsOfTestReportsProvingCompliance a samm:Property ;
+   samm:preferredName "result of test reports proving compliance"@en ;
+   samm:description "A battery passport must include the test report results that can prove the compliance with the requirements stated in the battery regulation.\n\n  DIN DKE Spec 99100 chapter reference: 6.2.8\n\n Document identifiers (e.g., depending of different languages) of a document (e.g., PDF) that can be found in the Handover Documentation model.\n\n "@en ;
+   samm:see <urn:irdi:0173-1#02-ABA705#003> ;
+   samm:characteristic shared:DocumentIdentifierSet .
+   
+:PuttingIntoServiceDate a samm:Characteristic ;
+   samm:dataType xsd:date .

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryNameplate.ttl
@@ -37,14 +37,16 @@
    samm:properties ( 
    [ samm:property :uriOfTheProduct; samm:payloadName "URIOfTheProduct" ] 
    [ samm:property :manufacturerName; samm:payloadName "ManufacturerName" ] 
-   [ samm:property :addressInformation; samm:payloadName "AddressInformation" ] 
+   [ samm:property :manufacturerIdentifier; samm:payloadName "ManufacturerIdentifier" ] 
+   [ samm:property :manufacturerAddressInformation; samm:payloadName "AddressInformation" ] 
    [ samm:property :serialNumber; samm:payloadName "SerialNumber" ] 
    [ samm:property :dateOfManufacture; samm:payloadName "DateOfManufacture" ] 
    [ samm:property :dateOfPuttingIntoService; samm:optional true; samm:payloadName "DateOfPuttingIntoService" ] 
    [ samm:property :uniqueFacilityIdentifier; samm:payloadName "UniqueFacilityIdentifier" ]
    [ samm:property :batteryStatus; samm:payloadName "LifeCycleStage" ]
+   [ samm:property :economicOperatorName; samm:optional true; samm:payloadName "EconomicOperatorName" ] 
    [ samm:property :operatorIdentifier; samm:optional true; samm:payloadName "OperatorIdentifier" ] 
-   [ samm:property tech:manufacturerIdentifier; samm:payloadName "ManufacturerIdentifier" ] 
+   [ samm:property :economicOperatorAddressInformation; samm:optional true; samm:payloadName "EconomicOperatorAddressInformation" ] 
    [ samm:property :markings; samm:payloadName "Markings" ] 
    [ samm:property :euDeclarationOfConformity; samm:payloadName "EUDeclarationOfConformity" ] 
    [ samm:property :resultsOfTestReportsProvingCompliance; samm:payloadName "ResultsOfTestReportsProvingCompliance" ] 
@@ -67,13 +69,19 @@
 :manufacturerName a samm:Property ;
    samm:preferredName "manufacturer name"@en ;
    samm:preferredName "Herstellername"@de ;
-   samm:description "Legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation.\n\n Information identifying the manufacturer with a name.Information identifying the manufacturer with a name.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.1"@en ;
+   samm:description "Name of manufacturer."@en ;
    samm:description "Name des Herstellers."@de ;
    samm:see <urn:irdi:0112/2///61987%23ABA565%23009> ;
    samm:see <urn:irdi:0173-1%2302-AAO677%23004> ;
    samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#manufacturerName> ;
    samm:exampleValue "Muster AG"@de ;
    samm:characteristic shared:MultiLanguageTexts .
+
+:manufacturerIdentifier a samm:Property ;
+   samm:see <urn:irdi:0173-1#02-AAO677#004> ;
+   samm:preferredName "identifier of the manufacturer"@en ;
+   samm:description "A battery passport must include information identifying the manufacturer.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.4"@en ;
+   samm:characteristic samm-c:Text .
 
 :serialNumber a samm:Property ;
    samm:preferredName "Seriennummer"@de ;
@@ -129,6 +137,16 @@
    samm:preferredName "identifier of the operator"@en ;
    samm:description "The unique operator identifier should comply with ISO/IEC 15459 1:2014, ISO/IEC 15459 2:2015, ISO/IEC 15459 3:2014, ISO/IEC 15459 4:2014, ISO/IEC 15459 5:2014, ISO/IEC 15459 6:2014, or their equivalent until referenced harmonised standards are listed in the OJEU.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3"@en ;
    samm:characteristic samm-c:Text .
+ 
+:economicOperatorName a samm:Property ;
+   samm:preferredName "economic operator name"@en ;
+   samm:description "Name of economic operator."@en ;
+   samm:description "Name des Herstellers."@de ;
+   samm:see <urn:irdi:0112/2///61987%23ABA565%23009> ;
+   samm:see <urn:irdi:0173-1%2302-AAO677%23004> ;
+   samm:see <urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#manufacturerName> ;
+   samm:exampleValue "Muster AG"@de ;
+   samm:characteristic shared:MultiLanguageTexts .
  
 :markings a samm:Property ;
    samm:preferredName "markings"@en ;

--- a/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryStatus_enum.ttl
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/1.1.0/BatteryStatus_enum.ttl
@@ -1,0 +1,64 @@
+######################################################################
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Industrial Digital Twin Association
+# This work  is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# elements of namespace: urn:samm:io.BatteryPass:GeneralProductInformation:1.2.0 
+# within https://github.com/batterypass/BatteryPassDataModel
+# with licence CC-BY-4.0
+# and Copyright (c) 2025 Circulor GmbH on behalf of the Battery Pass Consortium
+# are used but enhanced, adapted or changed to be compliant with DIN DKE SPEC 99100 
+# and to align with existing IDTA sub model templates
+#
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.1.0#> .
+
+
+ 
+:BatteryStatusEnumeration a samm-c:Enumeration ;
+   samm:description "Lifecycle status of the battery. Status defined from a list, with the options suggested as follows: 'original', 'repurposed', 'reused', 'remanufactured', 'waste'\n\nEUBR: Annex XIII (4c)"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( 
+	:Original 
+	:Repurposed 
+	:Reused
+	:Remanufactured
+	:Waste 
+	) .
+   
+:Original a samm:Value ;
+   samm:value "original" ;
+   samm:preferredName "original"@en ;
+   samm:see <urn:irdi:0173-1#07-ACC020#001> .
+   
+:Repurposed a samm:Value ;
+   samm:value "repurposed" ;
+   samm:preferredName "repurposed"@en ;
+   samm:see <urn:irdi:0173-1#07-ACC021#001> .
+   
+:Reused a samm:Value ;
+   samm:value "re-used" ;
+   samm:preferredName "re-used"@en ;
+   samm:see <urn:irdi:0173-1#07-ACC022#001> .
+   
+:Remanufactured a samm:Value ;
+   samm:value "remanufactured" ;
+   samm:preferredName "remanufactured"@en ;
+   samm:see <urn:irdi:0173-1#07-ACC023#001> .
+   
+:Waste a samm:Value ;
+   samm:value "waste" ;
+   samm:preferredName "waste"@en ;
+   samm:see <urn:irdi:0173-1#07-ACC024#001> .

--- a/io.admin-shell.idta.batterypass.digital_nameplate/README.md
+++ b/io.admin-shell.idta.batterypass.digital_nameplate/README.md
@@ -26,6 +26,19 @@ The folder "gen" for each version contains sammple JSON files, the JSON schema a
 # Changelog
 All notable changes to this model will be documented in this section.
 
+
+## [1.1.0] - April 2026
+
+Major changes:
+
+* add optional property :economicOperatorAddressInformation  (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])
+* rename :addressInformation to :manufacturerAddressInformation but payload name still remains "AddressInformation" (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])
+* add optional :economicOperatorName (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])
+
+Minor changes (no impact on payload)
+
+* no resue to tech: any longer for manufacturerIdentifier
+
 ## [1.0.0] - February 2026
 
 Contained Files:


### PR DESCRIPTION
closes #90
for changelog see also file README.md 

Major changes:

* add optional property :economicOperatorAddressInformation  (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])
* rename :addressInformation to :manufacturerAddressInformation but payload name still remains "AddressInformation" (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])
* add optional :economicOperatorName (https://github.com/admin-shell-io/smt-semantic-models/issues/90[#90])

Minor changes (no impact on payload)

* no reuse to tech: any longer for manufacturerIdentifier
